### PR TITLE
add StaticResponseFormatter for serving static files

### DIFF
--- a/CityWebServer.Extensibility/ApacheMimeTypes.cs
+++ b/CityWebServer.Extensibility/ApacheMimeTypes.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 // Source: https://raw.githubusercontent.com/cymen/ApacheMimeTypesToDotNet/master/ApacheMimeTypes.cs
-namespace ApacheMimeTypes
+namespace CityWebServer.Extensibility
 {
     internal class Apache
     {

--- a/CityWebServer.Extensibility/CityWebServer.Extensibility.csproj
+++ b/CityWebServer.Extensibility/CityWebServer.Extensibility.csproj
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ColossalManaged">
+      <HintPath>..\ColossalManaged.dll</HintPath>
+    </Reference>
     <Reference Include="JsonFx">
       <HintPath>..\packages\JsonFx.2.0.1209.2802\lib\net35\JsonFx.dll</HintPath>
     </Reference>
@@ -39,8 +42,12 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="UnityEngine">
+      <HintPath>..\UnityEngine.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ApacheMimeTypes.cs" />
     <Compile Include="IWebServer.cs" />
     <Compile Include="RequestHandlerBase.cs" />
     <Compile Include="ResponseFormatters\HtmlResponseFormatter.cs" />
@@ -51,6 +58,7 @@
     <Compile Include="LogAppenderEventArgs.cs" />
     <Compile Include="ResponseFormatters\PlainTextResponseFormatter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ResponseFormatters\StaticResponseFormatter.cs" />
     <Compile Include="RestfulRequestHandlerBase.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/CityWebServer.Extensibility/ResponseFormatters/StaticResponseFormatter.cs
+++ b/CityWebServer.Extensibility/ResponseFormatters/StaticResponseFormatter.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Net;
+using System.Linq;
+using System.Text;
+using System.IO;
+using ColossalFramework.Plugins;
+
+namespace CityWebServer.Extensibility.Responses
+{
+    internal class StaticResponseFormatter : IResponseFormatter
+    {
+        private readonly String _wwwroot;
+        private readonly HttpListenerRequest _request;
+
+        public StaticResponseFormatter(String wwwroot, HttpListenerRequest request)
+        {
+            _wwwroot = wwwroot;
+            _request = request;
+        }
+
+        public override void WriteContent(HttpListenerResponse response)
+        {
+            var relativePath = _request.Url.AbsolutePath.Substring(1);
+            relativePath = relativePath.Replace("/", Path.DirectorySeparatorChar.ToString());
+            var absolutePath = Path.Combine(_wwwroot, relativePath);
+
+            if (File.Exists(absolutePath))
+            {
+                var extension = Path.GetExtension(absolutePath);
+                response.ContentType = Apache.GetMime(extension);
+                response.StatusCode = 200; // HTTP 200 - SUCCESS
+
+                // Open file, read bytes into buffer and write them to the output stream.
+                using (FileStream fileReader = File.OpenRead(absolutePath))
+                {
+                    byte[] buffer = new byte[4096];
+                    int read;
+                    while ((read = fileReader.Read(buffer, 0, buffer.Length)) > 0)
+                    {
+                        response.OutputStream.Write(buffer, 0, read);
+                    }
+                }
+            }
+            else
+            {
+                String body = String.Format("No resource is available at the specified filepath: {0}", absolutePath);
+
+                IResponseFormatter notFoundResponseFormatter = new PlainTextResponseFormatter(body, HttpStatusCode.NotFound);
+                notFoundResponseFormatter.WriteContent(response);
+            }
+        }
+
+        /// <summary>
+        /// Gets the full path to the directory where static pages are served from.
+        /// Requires UNIQUE directory names across all mods.
+        /// </summary>
+        public static String GetWebRoot(String myRootPath)
+        {
+            var modPaths = PluginManager.instance.GetPluginsInfo().Select(obj => obj.modPath);
+            foreach (var path in modPaths)
+            {
+                var testPath = Path.Combine(path, myRootPath);
+
+                if (Directory.Exists(testPath))
+                {
+                    return testPath;
+                }
+            }
+            return null;
+        }
+
+    }
+}

--- a/CityWebServer/CityWebServer.csproj
+++ b/CityWebServer/CityWebServer.csproj
@@ -61,7 +61,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Helpers\ApacheMimeTypes.cs" />
     <Compile Include="Helpers\CitizenExtensions.cs" />
     <Compile Include="Helpers\ConfigurationHelper.cs" />
     <Compile Include="Helpers\DistrictExtensions.cs" />


### PR DESCRIPTION
This pull request adds a new response formatter to serve static files by moving the ServiceFileRequest from the IntegratedWebServer into the extensibility layer. This allows mods built on extensibility to easily serve static files in their handlers as a default/fallback.

This adds references to the Collosal/Unreal assemblies in the extensibility layer, which may not be desirable. This is only needed for moving the "GetWebRoot" to a place where other mods can use it, though. Getting rid of that relocation removes those assembly dependencies, at the drawback of each mod having to duplicate code to figure out their own static file root paths. In the current implementation, each mod needs to have a UNIQUE directory name, which is kind of dangerous anyway.
