### PR TITLE
Added Missing Nav, Updated Title and Stats Table

### DIFF
--- a/CityWebServer/wwwroot/index.html
+++ b/CityWebServer/wwwroot/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <title>Cities: Skylines - Test</title>
+    <title>Cities: Skylines - City Statistics</title>
     <link href='//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css' rel='stylesheet'>
     <style type="text/css">
         body { padding-top: 50px; }
@@ -22,24 +22,30 @@
                 <ul class="nav navbar-nav">
                     <li><a href="/">Home</a></li>
                     <li><a href="/Log">Log</a></li>
+                    <li><a href="/Budget">Budget</a></li>
+                    <li><a href="/Building">Building</a></li>
+                    <li><a href="/Messages">Chirper Messages</a></li>
+                    <li><a href="/CityInfo">City Info</a></li>
+                    <li><a href="/Transport">Transport</a></li>
+                    <li><a href="/Vehicle">Vehicle</a></li>
                     <!-- TODO: Dynamically populate this with links to other handlers.  -->
                 </ul>
             </div>
         </div>
     </nav>
     <div class="container">
-        <h1>Cities: Skylines - Integrated Web Server</h1>
+        <h1><span data-bind="text: Name">'s District Statistics</h1>
         <div id="chart"></div>
         <table class="table table-bordered table-striped">
             <thead>
                 <tr>
                     <th>District ID</th>
                     <th>Name</th>
-                    <th>Population</th>
-                    <th>Buildings</th>
-                    <th>Vehicles</th>
-                    <th>Households (Max)</th>
-                    <th>Jobs (Max)</th>
+                    <th>Population | vs World*</th>
+                    <th>Buildings | vs World*</th>
+                    <th>Vehicles | vs World*</th>
+                    <th>Households (Max) | %</th>
+                    <th>Jobs (Max) | %</th>
                     <th>Weekly Tourists</th>
                     <th>Land Value</th>
                     <th>Pollution</th>
@@ -51,11 +57,11 @@
             <tr>
                 <td data-bind="text: DistrictID"></td>
                 <td data-bind="text: DistrictName"></td>
-                <td data-bind="text: TotalPopulationCount"></td>
-                <td data-bind="text: TotalBuildingCount"></td>
-                <td data-bind="text: TotalVehicleCount"></td>
-                <td><span data-bind="text: CurrentHouseholds"></span> (<span data-bind="text: AvailableHouseholds"></span>)</td>
-                <td><span data-bind="text: CurrentJobs"></span> (<span data-bind="text: AvailableJobs"></span>)</td>
+                <td><span data-bind="text: TotalPopulationCount"></span> | <span data-bind="text: (TotalPopulationCount / GlobalDistrict.TotalPopulationCount).toFixed(0) + '%'"></span></td>
+                <td><span data-bind="text: TotalBuildingCount"></span> | <span data-bind="text: (TotalBuildingCount / GlobalDistrict.TotalBuildingCount).toFixed(0) + '%'"></span></td>
+                <td><span data-bind="text: TotalVehicleCount"></span> | <span data-bind="text: (TotalVehicleCount / GlobalDistrict.TotalVehicleCount).toFixed(0) + '%'"></span></td>
+                <td><span data-bind="text: CurrentHouseholds"></span> (<span data-bind="text: AvailableHouseholds"></span>) | <span data-bind="text: (CurrentHouseholds / AvailableHouseholds).toFixed(0) + '%'"></span></td>
+                <td><span data-bind="text: CurrentJobs"></span> (<span data-bind="text: AvailableJobs"></span>) | <span data-bind="text: (CurrentJobs / AvailableJobs).toFixed(0) + '%'"></span></td>
                 <td data-bind="text: WeeklyTouristVisits"></td>
                 <td data-bind="text: '₡' + AverageLandValue()"></td>
                 <td data-bind="text: (Pollution() * 100).toFixed(0) + '%'"></td>
@@ -69,8 +75,8 @@
                     <td data-bind="text: GlobalDistrict.TotalPopulationCount"></td>
                     <td data-bind="text: GlobalDistrict.TotalBuildingCount"></td>
                     <td data-bind="text: GlobalDistrict.TotalVehicleCount"></td>
-                    <td><span data-bind="text: GlobalDistrict.CurrentHouseholds"></span> (<span data-bind="text: GlobalDistrict.AvailableHouseholds"></span>)</td>
-                    <td><span data-bind="text: GlobalDistrict.CurrentJobs"></span> (<span data-bind="text: GlobalDistrict.AvailableJobs"></span>)</td>
+                    <td><span data-bind="text: GlobalDistrict.CurrentHouseholds"></span> (<span data-bind="text: GlobalDistrict.AvailableHouseholds"></span>) | <span data-bind="text: (CurrentHouseholds / AvailableHouseholds).toFixed(0) + '%'"></span></td>
+                    <td><span data-bind="text: GlobalDistrict.CurrentJobs"></span> (<span data-bind="text: GlobalDistrict.AvailableJobs"></span>) | <span data-bind="text: (GlobalDistrict.CurrentJobs / GlobalDistrict.AvailableJobs).toFixed(0) + '%'"></span></td>
                     <td data-bind="text: GlobalDistrict.WeeklyTouristVisits"></td>
                     <td data-bind="text: '₡' + GlobalDistrict.AverageLandValue()"></td>
                     <td data-bind="text: (GlobalDistrict.Pollution() * 100).toFixed(0) + '%'"></td>
@@ -78,6 +84,14 @@
             </tfoot>
         </table>
     </div>
+    <nav class="navbar bg-light">
+        <div class="container-fluid">
+            <span class="navbar-text">
+                * The vs World is a comparision between the distict and the rest of the world within the saved game. Due to the Total row being the value of the rest of the world for the specified column(s), the total row will not contail a vs World value.
+            </span>
+        </div>
+    </nav>
+        
     <script src='./jquery-2.1.3.min.js'></script>
     <script src='./bootstrap.min.js'></script>
     <script src='./knockout-3.3.0.js'></script>

--- a/CityWebServer/wwwroot/index.html
+++ b/CityWebServer/wwwroot/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
@@ -28,13 +28,12 @@
                     <li><a href="/CityInfo">City Info</a></li>
                     <li><a href="/Transport">Transport</a></li>
                     <li><a href="/Vehicle">Vehicle</a></li>
-                    <!-- TODO: Dynamically populate this with links to other handlers.  -->
                 </ul>
             </div>
         </div>
     </nav>
     <div class="container">
-        <h1><span data-bind="text: Name">'s District Statistics</h1>
+        <h1><span data-bind="text: Name"> Statistics</h1>
         <div id="chart"></div>
         <table class="table table-bordered table-striped">
             <thead>
@@ -44,8 +43,8 @@
                     <th>Population | vs World*</th>
                     <th>Buildings | vs World*</th>
                     <th>Vehicles | vs World*</th>
-                    <th>Households (Max) | %</th>
-                    <th>Jobs (Max) | %</th>
+                    <th>Households (Max) | % Full</th>
+                    <th>Jobs (Max) | % Full</th>
                     <th>Weekly Tourists</th>
                     <th>Land Value</th>
                     <th>Pollution</th>
@@ -57,14 +56,14 @@
             <tr>
                 <td data-bind="text: DistrictID"></td>
                 <td data-bind="text: DistrictName"></td>
-                <td><span data-bind="text: TotalPopulationCount"></span> | <span data-bind="text: (TotalPopulationCount / GlobalDistrict.TotalPopulationCount).toFixed(0) + '%'"></span></td>
-                <td><span data-bind="text: TotalBuildingCount"></span> | <span data-bind="text: (TotalBuildingCount / GlobalDistrict.TotalBuildingCount).toFixed(0) + '%'"></span></td>
-                <td><span data-bind="text: TotalVehicleCount"></span> | <span data-bind="text: (TotalVehicleCount / GlobalDistrict.TotalVehicleCount).toFixed(0) + '%'"></span></td>
-                <td><span data-bind="text: CurrentHouseholds"></span> (<span data-bind="text: AvailableHouseholds"></span>) | <span data-bind="text: (CurrentHouseholds / AvailableHouseholds).toFixed(0) + '%'"></span></td>
-                <td><span data-bind="text: CurrentJobs"></span> (<span data-bind="text: AvailableJobs"></span>) | <span data-bind="text: (CurrentJobs / AvailableJobs).toFixed(0) + '%'"></span></td>
+                <td><span data-bind="text: TotalPopulationCount"></span> | <span data-bind="text: TotalPopulationCount"></span></td>
+                <td data-bind="text: TotalBuildingCount"></td>
+                <td data-bind="text: TotalVehicleCount"></td>
+                <td><span data-bind="text: CurrentHouseholds"></span> (<span data-bind="text: AvailableHouseholds"></span>)</td>
+                <td><span data-bind="text: CurrentJobs"></span> (<span data-bind="text: AvailableJobs"></span>)</td>
                 <td data-bind="text: WeeklyTouristVisits"></td>
                 <td data-bind="text: '₡' + AverageLandValue()"></td>
-                <td data-bind="text: (Pollution() * 100).toFixed(0) + '%'"></td>
+                <td data-bind="text: (Pollution() * 100).toFixed(2) + '%'"></td>
             </tr>
             <!-- /ko -->
             </tbody>
@@ -75,23 +74,23 @@
                     <td data-bind="text: GlobalDistrict.TotalPopulationCount"></td>
                     <td data-bind="text: GlobalDistrict.TotalBuildingCount"></td>
                     <td data-bind="text: GlobalDistrict.TotalVehicleCount"></td>
-                    <td><span data-bind="text: GlobalDistrict.CurrentHouseholds"></span> (<span data-bind="text: GlobalDistrict.AvailableHouseholds"></span>) | <span data-bind="text: (CurrentHouseholds / AvailableHouseholds).toFixed(0) + '%'"></span></td>
-                    <td><span data-bind="text: GlobalDistrict.CurrentJobs"></span> (<span data-bind="text: GlobalDistrict.AvailableJobs"></span>) | <span data-bind="text: (GlobalDistrict.CurrentJobs / GlobalDistrict.AvailableJobs).toFixed(0) + '%'"></span></td>
+                    <td><span data-bind="text: GlobalDistrict.CurrentHouseholds"></span> (<span data-bind="text: GlobalDistrict.AvailableHouseholds"></span>) | <span data-bind="text: ((GlobalDistrict.CurrentHouseholds() / GlobalDistrict.AvailableHouseholds()).toFixed(2)) * 100 + '%'"></span></td>
+                    <td><span data-bind="text: GlobalDistrict.CurrentJobs"></span> (<span data-bind="text: GlobalDistrict.AvailableJobs"></span>) | <span data-bind="text: ((GlobalDistrict.CurrentJobs() / GlobalDistrict.AvailableJobs()).toFixed(2)) * 100 + '%'"></span></td>
                     <td data-bind="text: GlobalDistrict.WeeklyTouristVisits"></td>
                     <td data-bind="text: '₡' + GlobalDistrict.AverageLandValue()"></td>
-                    <td data-bind="text: (GlobalDistrict.Pollution() * 100).toFixed(0) + '%'"></td>
+                    <td data-bind="text: (GlobalDistrict.Pollution() * 100).toFixed(2) + '%'"></td>
                 </tr>
             </tfoot>
         </table>
     </div>
-    <nav class="navbar bg-light">
+
+<nav class="navbar bg-light">
         <div class="container-fluid">
             <span class="navbar-text">
                 * The vs World is a comparision between the distict and the rest of the world within the saved game. Due to the Total row being the value of the rest of the world for the specified column(s), the total row will not contail a vs World value.
             </span>
         </div>
     </nav>
-        
     <script src='./jquery-2.1.3.min.js'></script>
     <script src='./bootstrap.min.js'></script>
     <script src='./knockout-3.3.0.js'></script>


### PR DESCRIPTION
Changes:
Updated the title from Cities Skylines: Test to Cities Skylines: Statistics.  Updated title on page from Cities: Skylines - Integrated Server to <cityname> District Statistics.  Added missing nav links. -- These are not "working" as of yet. Updating the statistics table with additional information for each district.

Feature Plans:
While the additional links added to the nav bar do not contain a "pretty" webpage, it is a starting point. I'd like to eventually get these pages displaying human readable information. This index page (or perhaps a new page) would be interesting to contain a history chart in addition to the graph so that the actual numbers can be viewed. Also, the table already displayed on this page would be greatly improved by notating whether the value has increase or decrease since the last update. 

Note: I have not tested these modifications.